### PR TITLE
Generate savegame file automatically when it does not exist

### DIFF
--- a/src/logic/SudokuSettings.vala
+++ b/src/logic/SudokuSettings.vala
@@ -41,6 +41,11 @@ namespace Application {
                 if (!dataFolder.query_exists ()) {
                     dataFolder.make_directory ();
                 }
+
+                if (!isSaved_file (saveFile)) {
+                    dataFolder.get_child (saveFile).create (FileCreateFlags.NONE);
+                }
+
                 if (isSaved_file (highscoreFile)) {
                     _highscore = int.parse (load_file (highscoreFile));
                 }


### PR DESCRIPTION
At the moment the destination folder is automatically generated when it does not exist, but the `savegame` file is not. So you'll see an error like this:

```
ERROR 17:43:07.538810] SudokuSettings.vala:69: Error opening file /home/ryo/.local/share/com.github.bartzaalberg.sudokular/savegame: No such file or directory
Trace/breakpoint trap
```
